### PR TITLE
fix(clojure): disable nvim-treesitter-sexp for neovim 0.11

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
@@ -5,3 +5,5 @@ A plugin for Neovim for editing code by manipulating the Treesitter AST. Basical
 Supported Languages: Clojure, Fennel, Janet, Query
 
 **Repository:** <https://github.com/PaterJason/nvim-treesitter-sexp>
+
+> NOTE: Disabled for Neovim 0.11 (treesitter breaking changes)

--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
@@ -1,6 +1,7 @@
 return {
   "PaterJason/nvim-treesitter-sexp",
   dependencies = { "nvim-treesitter/nvim-treesitter" },
+  enabled = vim.fn.has "nvim-0.11" == 0,
   ft = { "clojure", "fennel", "janet", "query" },
   cmd = "TSSexp",
   opts = {},


### PR DESCRIPTION
nvim-treesitter-sexp fails when using its commands for neovim 0.11 and
AstroNvim v5

This plugin is failing due to breaking changes in treesitter since
neovim 0.11

https://github.com/practicalli/neovim/issues/62#issuecomment-2772653311
